### PR TITLE
Fix handling of service files with invalid syntax

### DIFF
--- a/pgservicefile.go
+++ b/pgservicefile.go
@@ -60,7 +60,7 @@ func ParseServicefile(r io.Reader) (*Servicefile, error) {
 		} else {
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) != 2 {
-				fmt.Errorf("unable to parse line %d", lineNum)
+				return nil, fmt.Errorf("unable to parse line %d", lineNum)
 			}
 
 			key := strings.TrimSpace(parts[0])

--- a/pgservicefile_test.go
+++ b/pgservicefile_test.go
@@ -51,3 +51,11 @@ application_name = has space
 	assert.Equal(t, "defuser", def.Settings["user"])
 	assert.Equal(t, "has space", def.Settings["application_name"])
 }
+
+func TestParseServicefileWithInvalidFile(t *testing.T) {
+	buf := bytes.NewBufferString("Invalid syntax\n")
+
+	servicefile, err := pgservicefile.ParseServicefile(buf)
+	assert.Error(t, err)
+	assert.Nil(t, servicefile)
+}


### PR DESCRIPTION
I ran into a panic when my service file was invalid (I accidentally used the wrong comment character), and found this typo (missing return).