### PR TITLE
Missing service

### DIFF
--- a/pgservicefile.go
+++ b/pgservicefile.go
@@ -58,6 +58,10 @@ func ParseServicefile(r io.Reader) (*Servicefile, error) {
 			service = &Service{Name: line[1 : len(line)-1], Settings: make(map[string]string)}
 			servicefile.Services = append(servicefile.Services, service)
 		} else {
+			if service == nil {
+				return nil, errors.New("missing service")
+			}
+
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("unable to parse line %d", lineNum)

--- a/pgservicefile_test.go
+++ b/pgservicefile_test.go
@@ -23,6 +23,7 @@ host = def.example.com
 dbname = defdb
 user = defuser
 application_name = has space
+password=abc=12@
 `)
 
 	servicefile, err := pgservicefile.ParseServicefile(buf)
@@ -53,9 +54,19 @@ application_name = has space
 }
 
 func TestParseServicefileWithInvalidFile(t *testing.T) {
-	buf := bytes.NewBufferString("Invalid syntax\n")
+	t.Run("invalid syntax", func(t *testing.T) {
+		buf := bytes.NewBufferString("Invalid syntax\n")
 
-	servicefile, err := pgservicefile.ParseServicefile(buf)
-	assert.Error(t, err)
-	assert.Nil(t, servicefile)
+		servicefile, err := pgservicefile.ParseServicefile(buf)
+		assert.Error(t, err)
+		assert.Nil(t, servicefile)
+	})
+
+	t.Run("missing service name", func(t *testing.T) {
+		buf := bytes.NewBufferString("username=usr1\n")
+
+		servicefile, err := pgservicefile.ParseServicefile(buf)
+		assert.Error(t, err)
+		assert.Nil(t, servicefile)
+	})
 }

--- a/pgservicefile_test.go
+++ b/pgservicefile_test.go
@@ -23,7 +23,7 @@ host = def.example.com
 dbname = defdb
 user = defuser
 application_name = has space
-password=abc=12@
+password=has=symbol
 `)
 
 	servicefile, err := pgservicefile.ParseServicefile(buf)


### PR DESCRIPTION
Resolves:

```
055Z stderr F panic: runtime error: invalid memory address or nil pointer dereference
2023-11-27T16:11:01.36603712Z stderr F [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6e691c]
2023-11-27T16:11:01.366038712Z stderr F 
2023-11-27T16:11:01.366040287Z stderr F goroutine 1 [running]:
2023-11-27T16:11:01.366041661Z stderr F github.com/jackc/pgservicefile.ParseServicefile({0x15aaea0, 0xc00007a370})
2023-11-27T16:11:01.366043058Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgservicefile@v0.0.0-20221227161230-091c0ba34f0a/pgservicefile.go:69 +0x33c
2023-11-27T16:11:01.366044364Z stderr F github.com/jackc/pgservicefile.ReadServicefile({0xc00004600e?, 0x4102c5?})
2023-11-27T16:11:01.36604556Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgservicefile@v0.0.0-20221227161230-091c0ba34f0a/pgservicefile.go:40 +0x9d
2023-11-27T16:11:01.366049702Z stderr F github.com/jackc/pgx/v5/pgconn.parseServiceSettings({0xc00004600e, 0x1a}, {0xc00004800a, 0x7})
2023-11-27T16:11:01.366051151Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.0/pgconn/config.go:581 +0x45
2023-11-27T16:11:01.366052801Z stderr F github.com/jackc/pgx/v5/pgconn.ParseConfigWithOptions({0x0, 0x0}, {0x21e2840?})
2023-11-27T16:11:01.366054623Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.0/pgconn/config.go:247 +0x445
2023-11-27T16:11:01.366057014Z stderr F github.com/jackc/pgx/v5.ParseConfigWithOptions({0x0, 0x0}, {{0x0?}})
2023-11-27T16:11:01.366060925Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.0/conn.go:147 +0x2f
2023-11-27T16:11:01.366067586Z stderr F github.com/jackc/pgx/v5.ParseConfig(...)
2023-11-27T16:11:01.366069448Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.0/conn.go:218
2023-11-27T16:11:01.366071508Z stderr F github.com/jackc/pgx/v5/pgxpool.ParseConfig({0x0?, 0x0?})
2023-11-27T16:11:01.366075329Z stderr F 	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.0/pgxpool/pool.go:288 +0x2a
2023-11-27T16:11:01.366079649Z stderr F github.com/tetrateio/n2ac/cluster-server/internal/cmd.reposForPostgres({0x15cb888, 0x2211920}, 0xc0002dfb90, 0x1)
2023-11-27T16:11:01.366084023Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/internal/cmd/cmd.go:176 +0x9c
2023-11-27T16:11:01.366087149Z stderr F github.com/tetrateio/n2ac/cluster-server/internal/cmd.store({0x15cb888, 0x2211920}, 0xc0001d2790)
2023-11-27T16:11:01.366089681Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/internal/cmd/cmd.go:142 +0x186
2023-11-27T16:11:01.366108014Z stderr F github.com/tetrateio/n2ac/cluster-server/internal/cmd.dependencies({0x15cb888?, 0x2211920?}, 0x10?, {0x15d0ce0?, 0xc0002dfd70})
2023-11-27T16:11:01.366109224Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/internal/cmd/cmd.go:122 +0x30
2023-11-27T16:11:01.366128924Z stderr F github.com/tetrateio/n2ac/cluster-server/internal/cmd.newApp.run.func1(0xc00018f080?)
2023-11-27T16:11:01.366130291Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/internal/cmd/cmd.go:109 +0x17b
2023-11-27T16:11:01.366131491Z stderr F github.com/urfave/cli/v2.(*Command).Run(0xc00018f080, 0xc0003b2440, {0xc00003e1e0, 0x6, 0x6})
2023-11-27T16:11:01.366133935Z stderr F 	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x998
2023-11-27T16:11:01.366156027Z stderr F github.com/urfave/cli/v2.(*App).RunContext(0xc0003b01e0, {0x15cb888?, 0x2211920}, {0xc00003e1e0, 0x6, 0x6})
2023-11-27T16:11:01.366158914Z stderr F 	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x5b7
2023-11-27T16:11:01.366181756Z stderr F github.com/tetrateio/n2ac/cluster-server/internal/cmd.Run({0x15cb888, 0x2211920}, {0x15c5bc0?, 0x101c00003e060?}, {0x15aad60?, 0xc00007a028?}, {0x15aad60, 0xc00007a030}, {0xc00003e1e0, 0x6, ...})
2023-11-27T16:11:01.366185621Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/internal/cmd/cmd.go:64 +0x89
2023-11-27T16:11:01.3661939Z stderr F main.main()
2023-11-27T16:11:01.366200032Z stderr F 	/home/runner/work/n2ac/n2ac/cluster-server/main.go:40 +0x233
```